### PR TITLE
Grabs footer image for social media previews

### DIFF
--- a/bin/filter.rb
+++ b/bin/filter.rb
@@ -24,6 +24,13 @@ def process(data, force_header: nil, format_for_frontpage: false)
 
   doc = Nokogiri::HTML::DocumentFragment.parse(body)
 
+  # Grab footer image for social media previews
+  if !(header =~ /image:/i)
+    image = doc.css("img.mcnImage").last
+    image_url = image['src']
+    header = header + "image: #{image_url}\n"
+  end
+
   # Add 'highlight' class to tables because it bypasses our template's default formatting.
   doc.css("table").each do |node|
     node['class'] = (node['class'] || '') + ' highlight' unless (node['class'] || '') =~ /highlight/

--- a/bin/filter.rb
+++ b/bin/filter.rb
@@ -25,7 +25,7 @@ def process(data, force_header: nil, format_for_frontpage: false)
   doc = Nokogiri::HTML::DocumentFragment.parse(body)
 
   # Grab footer image for social media previews
-  if header !~ /^image:/i
+  if !format_for_frontpage && header !~ /^image:/i
     image = doc.css("img.mcnImage").last
     image_url = image['src']
     header = header + "image: #{image_url}\n"

--- a/bin/filter.rb
+++ b/bin/filter.rb
@@ -25,7 +25,7 @@ def process(data, force_header: nil, format_for_frontpage: false)
   doc = Nokogiri::HTML::DocumentFragment.parse(body)
 
   # Grab footer image for social media previews
-  if !(header =~ /image:/i)
+  if header !~ /^image:/i
     image = doc.css("img.mcnImage").last
     image_url = image['src']
     header = header + "image: #{image_url}\n"


### PR DESCRIPTION
Puts the URL from the last `mcnImage`  into the front matter if an 'image: ' field doesn't already exist.